### PR TITLE
chore: test without extractVersion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,6 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
-      "description": "Remove leading v from hugo version",
-      "extractVersion": "^v(?<version>)",
-      "matchDatasources": ["github-releases"],
-      "matchPackageNames": ["gohugoio/hugo"]
-    },
-    {
       "description": "Automatically merge minor updates",
       "matchManagers": ["github-actions", "gomod", "pre-commit", "regex"],
       "matchUpdateTypes": ["minor", "patch", "digest"],


### PR DESCRIPTION
Test without the extractVersion to find why the datasource does not find any package versions.
