### PR TITLE
chore: automerge all non-major upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,6 @@
     },
     {
       "description": "Automatically merge minor updates",
-      "matchManagers": ["github-actions", "gomod", "pre-commit", "regex"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }


### PR DESCRIPTION
This automerges all non-major dependency updates.
