### PR TITLE
docs: add more information about recentEnvelopes

### DIFF
--- a/content/en/docs/Reference/api/v2/_index.md
+++ b/content/en/docs/Reference/api/v2/_index.md
@@ -28,4 +28,6 @@ This describes general behavior of all API endpoints
 
 ## Migrating from v1
 
-_All changes are covered in [Changed in v2](#changed-in-v2)_
+_Changes to all endpoints are covered in [Changed in v2](#changed-in-v2)._
+
+For changes to the different resources, check their respective pages.

--- a/content/en/docs/Reference/api/v2/accounts.md
+++ b/content/en/docs/Reference/api/v2/accounts.md
@@ -1,0 +1,19 @@
+---
+title: "Accounts"
+description: >
+  This document describes Accounts in API version 2
+---
+
+## Recent Envelopes
+
+The `recentEnvelopes` field is a list of the 5 most common Envelopes that were used for the last 50 transactions where the account was the destination.
+The list is ordered by the frequency with the most common Envelope being the first one. If two Envelopes have been used the same amount of times,
+the one that was created **more recently** is first in the list.
+
+Income transactions are also counted in this list, with income appearing as the `null` value.
+
+Use this field to pre-fill the Envelope when creating transactions in a client.
+
+## Migrating from v1
+
+- The `recentEnvelopes` field is now a list of IDs instead of a list envelope objects. Income is represented by `null`


### PR DESCRIPTION
Extends the API v2 documentation for `recentEnvelopes`
