### PR TITLE
docs: add v3 JSON schemas

### DIFF
--- a/content/en/docs/Reference/api/v3.md
+++ b/content/en/docs/Reference/api/v3.md
@@ -1,0 +1,27 @@
+---
+title: "v3"
+description: >
+  This document describes API version 3
+---
+
+{{% alert title="Unstable" color="warning" %}}
+API v3 is not yet finalized. The specification will be final when the first backend version with an API v3 endpoint is published.
+{{% /alert %}}
+
+## General
+
+This describes general behavior of all API endpoints
+
+- All API responses either have an empty body (only for HTTP 204 responses) or the body consists of only JSON. (unchanged from v1, v2)
+- All attributes for a resource are always contained in the objects that the API returns. (unchanged from v1, v2)
+- The `error` property is either a string or `null`. Each non-204 API response always contains an `error` property (**changed from v1, v2**)
+- The `data` property is either an array of objects for collection endpoints or a single object for resource endpoints. (unchanged from v2)
+- `POST` endpoints take a array of objects to be created. The response will also be a list of objects, where every object has a `data` and an `error` property. If an error ocurred, `error` will contain an error message. If no error occurs, `error` is `null` and `data` contains the created resource. (unchanged from v2)
+- `PATCH` endpoints and `GET` resource endpoints return an object with an `error` and a `data` property. If an error ocurred, the `error` property contains a human readable error message intended for the end user. If no error occurs, `error` is null and `data` contains the resource (**changed from v2**)
+- `GET` collection endpoints return an object with an `error` and a `data` property. If an error ocurred, the `error` property contains a human readable error message intended for the end user. If no error occurs, `error` is null and `data` contains an array of objects where each object is a resource (**changed from v2**)
+
+## JSON Schemas
+
+This is a full list of all JSON schemas for the response bodies.
+
+{{< directoryindex path="/static/schemas/v3" pathURL="/schemas/v3" >}}

--- a/layouts/shortcodes/directoryindex.html
+++ b/layouts/shortcodes/directoryindex.html
@@ -1,0 +1,8 @@
+{{- $pathURL := .Get "pathURL" -}} {{- $path := .Get "path" -}} {{- $files :=
+readDir $path -}}
+<ul>
+  {{- range $files }}
+  <li>
+    <a href="{{ $pathURL }}{{ .Name | relURL }}"> {{ .Name }}</a> {{- end }}
+  </li>
+</ul>

--- a/static/schemas/v3/error.schema.json
+++ b/static/schemas/v3/error.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envelope-zero.org/schemas/v3/error.schema.json",
+  "title": "Error",
+  "description": "A human readable error message",
+  "anyOf": [{ "type": "string" }, { "type": "null" }]
+}

--- a/static/schemas/v3/get-collection.schema.json
+++ b/static/schemas/v3/get-collection.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envelope-zero.org/schemas/v3/get-collection.schema.json",
+  "title": "HTTP GET - Collection Endpoints",
+  "description": "The HTTP response body for GET collection endpoints",
+  "type": "object",
+  "required": ["data", "error", "pagination"],
+  "properties": {
+    "data": {
+      "description": "List of resources",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "error": {
+      "$ref": "https://envelope-zero.org/schemas/v3/error.schema.json"
+    },
+    "pagination": {
+      "$ref": "https://envelope-zero.org/schemas/v3/pagination.schema.json"
+    }
+  }
+}

--- a/static/schemas/v3/get-patch-resource.schema.json
+++ b/static/schemas/v3/get-patch-resource.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envelope-zero.org/schemas/v3/get-patch-resource.schema.json",
+  "title": "HTTP GET/PATCH - Resource Endpoint",
+  "description": "The HTTP response body for GET/PATCH resource endpoints",
+  "type": "object",
+  "required": ["data", "error"],
+  "properties": {
+    "data": {
+      "description": "The resource",
+      "type": "object"
+    },
+    "error": {
+      "$ref": "https://envelope-zero.org/schemas/v3/error.schema.json"
+    }
+  }
+}

--- a/static/schemas/v3/pagination.schema.json
+++ b/static/schemas/v3/pagination.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envelope-zero.org/schemas/v3/pagination.schema.json",
+  "title": "Pagination",
+  "description": "The pagination information",
+  "type": "object",
+  "required": [
+    "total_records",
+    "current_page",
+    "total_pages",
+    "next_page",
+    "prev_page"
+  ],
+  "properties": {
+    "total_records": {
+      "description": "The total amount of resources for the query",
+      "anyOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
+    },
+    "current_page": {
+      "description": "The page currently viewed",
+      "anyOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+    },
+    "total_pages": {
+      "description": "The number of pages for the query",
+      "anyOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+    },
+    "next_page": {
+      "description": "The next page",
+      "anyOf": [{ "type": "integer", "minimum": 2 }, { "type": "null" }]
+    },
+    "prev_page": {
+      "description": "The previous page",
+      "anyOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+    }
+  }
+}

--- a/static/schemas/v3/post-collection.json
+++ b/static/schemas/v3/post-collection.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envelope-zero.org/schemas/v3/get-collection.schema.json",
+  "title": "HTTP GET - Collection Endpoints",
+  "description": "The HTTP response body for GET collection endpoints",
+  "type": "object",
+  "required": ["data", "error"],
+  "properties": {
+    "data": {
+      "description": "List of resources",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "https://envelope-zero.org/schemas/v3/error.schema.json"
+          },
+          "data": {
+            "description": "A single resource",
+            "type": "object"
+          }
+        }
+      }
+    },
+    "error": {
+      "$ref": "https://envelope-zero.org/schemas/v3/error.schema.json"
+    }
+  }
+}


### PR DESCRIPTION
This adds JSON schemas for API v3.

**Note**: These schemas might still change until the first backend release
with an API v3 endpoint is made.
