### PR TITLE
chore: make docsy a direct dependency to be updated with renovate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/envelope-zero/docs
 
 go 1.20
 
-require github.com/google/docsy v0.6.0 // indirect
+require github.com/google/docsy v0.6.0


### PR DESCRIPTION
This makes docsy a direct dependency so that it is upgraded with renovate.
