### PR TITLE
docs: remove deletedAt from API documentation, since it is removed from the backend with v6.0.6

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -7,11 +7,11 @@ exclude_search = true
 {{< blocks/cover title="Welcome to Envelope Zero!" image_anchor="center" height="max" color="dark" >}}
 <div class="mx-auto">
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "Concepts" >}}">
-		Concepts<i class="fas fa-arrow-alt-circle-right ml-2"></i>
+		Concepts
 	</a>
   <!-- TODO: relref to getting started -->
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="{{< relref "Setup" >}}">
-		Get started<i class="fa-regular fa-download ml-2 "></i>
+		Get started
 	</a>
 </div>
 {{< /blocks/cover >}}
@@ -24,7 +24,7 @@ All parts of the projects are free and Open Source.
 If you're new to this budgeting method, we recommend to check out the <a href="{{< relref "/docs/concepts" >}}">Concepts</a>. We'll explain how zero-based envelope budgeting works and you'll learn to use Envelope Zero along the way.
 {{% /blocks/lead %}}
 
-{{< blocks/section color="secondary">}}
+{{< blocks/section color="secondary" type="row" >}}
 {{% blocks/feature icon="far fa-question" title="Questions" %}}
 Ask <a href="https://github.com/orgs/envelope-zero/discussions">on GitHub</a> or send an email to team@envelope-zero.org
 {{% /blocks/feature %}}

--- a/content/en/docs/Reference/api/_index.md
+++ b/content/en/docs/Reference/api/_index.md
@@ -22,7 +22,6 @@ All resources share the following **read only** attributes:
 
 - `createdAt` (string): An RFC3339 timestamp of the time when the resource was created.
 - `updatedAt` (string): An RFC3339 timestamp of the time when the resource was updated.
-- `deletedAt` (string): An RFC3339 timestamp of the time when the resource was deleted. Can be null.
 - `id` (string): The UUID of the object.
 - `links` (object): A map of related resources.
   - `self` (string): The full URL of the resource itself.

--- a/content/en/docs/Usage/setup.md
+++ b/content/en/docs/Usage/setup.md
@@ -7,8 +7,6 @@ description: >
 
 {{% pageinfo %}}
 Envelope Zero supports two general installation methods: The **standalone** version and the **services** version. Before you continue, please check out which version is better suited to your needs.
-
-This page will be expanded soon.
 {{% /pageinfo %}}
 
 ## Standalone vs. Services
@@ -35,4 +33,4 @@ Set up the backend first. Follow the instructions in https://github.com/envelope
 
 Then, set up the frontend. Follow the instructions in https://github.com/envelope-zero/frontend#deployment.
 
-Since the frontend expects the backend to be available at the same hostname under the `/api` path, you will have to rewrite requests to the backend to remove the `/api` prefix from the path. For now, please consult your reverse proxy's documentation for how to do this. We will add documentation about this later.
+Since the frontend expects the backend to be available at the same hostname under the `/api` path, you will have to rewrite requests to the backend to remove the `/api` prefix from the path. For now, please consult your reverse proxy's documentation for how to do this.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/envelope-zero/docs
 
 go 1.20
+
+require (
+	github.com/google/docsy v0.11.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
+github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,12 +16,11 @@ params:
   github_repo: "https://github.com/envelope-zero/docs"
   # github_project_repo: ""
   github_branch: main
-  algolia_docsearch: false
   offlineSearch: true
   prism_syntax_highlighting: false
   ui:
     breadcrumb_disable: false
-    footer_about_disable: true
+    footer_about_enable: false
     navbar_logo: true
     navbar_translucent_over_cover_disable: false
     sidebar_menu_compact: false


### PR DESCRIPTION
Remove `deletedAt` field, since it is removed with v6.0.6 of the backend.

Also fixes a few formatting issues and outdated hints.